### PR TITLE
Fix plugin exit when transport is SMTP

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ const fastifyNodemailer = (fastify, options, next) => {
 }
 
 const close = (fastify, done) => {
+  if (fastify.nodemailer.transporter.on) {
+    fastify.nodemailer.transporter.on('close', done)
+  }
+
   fastify.nodemailer.close(done)
 }
 

--- a/test.js
+++ b/test.js
@@ -96,3 +96,19 @@ t.test('customTransport', t => {
       })
     })
 })
+
+t.test('disposing resources', t => {
+  const fastify = Fastify()
+
+  fastify
+    .register(nodemailer, {
+      url: 'smtp-transport'
+    })
+    .ready(err => {
+      t.error(err)
+
+      fastify.close().then(() => {
+        t.end()
+      })
+    })
+})

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const t = require('tap')
 const Fastify = require('fastify')
 const nodemailer = require('./')
 
-t.jobs = 4
+t.jobs = 5
 
 t.test('nodemailer exists', t => {
   const fastify = Fastify()


### PR DESCRIPTION
Problem: The plugin does not exit correctly when the transport is SMTP.

Why:
Triggering the `fastify.nodemailer.close(done)` is expected to
start disposing of resources procedure. However [the mailer implementation](https://github.com/nodemailer/nodemailer/blob/master/lib/mailer/index.js#L95)
proxies the execution to the [underlying SMTP transport](https://github.com/nodemailer/nodemailer/blob/master/lib/smtp-transport/index.js#L399).
In order to exit properly (after the plugin successfully closed),
the callback has to be called on the plugin event `close`.